### PR TITLE
Fix xib not included in pod

### DIFF
--- a/KKColorListPicker.podspec
+++ b/KKColorListPicker.podspec
@@ -8,6 +8,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.ios.deployment_target = '7.0'
   s.source       = { :git => "https://github.com/leoru/KKColorListPicker.git", :tag => "v0.2.2" }
-  s.source_files = 'src/KKColorListPicker/**/*.{h,m,xib,plist}'
+  s.source_files = 'src/KKColorListPicker/**/*.{h,m,plist}'
   s.resources    = 'src/KKColorListPicker/**/*.{xib}'
 end


### PR DESCRIPTION
This fixes .xib not being included in the CocoaPod, which addresses issue #2.
