### PR TITLE
Cocoa pods Framework fix - use of framework - NSBUDLE Class

### DIFF
--- a/src/KKColorListPicker/Classes/KKColor.h
+++ b/src/KKColorListPicker/Classes/KKColor.h
@@ -14,9 +14,9 @@
 @property (nonatomic, strong) NSString *name;
 
 // color hex
-@property (nonatomic, strong) NSString *colorHash;
+@property (nonatomic, strong) NSString *hashString;
 
-- (instancetype)initWithName:(NSString *)newName colorHash:(NSString *)colorHash;
+- (instancetype)initWithName:(NSString *)newName hash:(NSString *)newHash;
 
 // to UIColor
 - (UIColor *)uiColor;

--- a/src/KKColorListPicker/Classes/KKColor.m
+++ b/src/KKColorListPicker/Classes/KKColor.m
@@ -11,19 +11,19 @@
 
 @implementation KKColor
 
-- (instancetype)initWithName:(NSString *)newName colorHash:(NSString *)colorHash
+- (instancetype)initWithName:(NSString *)newName hash:(NSString *)newHash
 {
     self = [self init];
     if (self) {
         self.name = newName;
-        self.colorHash = colorHash;
+        self.hashString = newHash;
     }
     return self;
 }
 
 - (UIColor *)uiColor
 {
-    return [UIColor colorFromHexString:self.colorHash];
+    return [UIColor colorFromHexString:self.hashString];
 }
 
 @end

--- a/src/KKColorListPicker/Classes/KKColorsLoader.m
+++ b/src/KKColorListPicker/Classes/KKColorsLoader.m
@@ -25,6 +25,7 @@
 
 + (NSArray *)colorsArrayForColorsSchemeType:(KKColorsSchemeType)schemeType
 {
+    NSBundle *podbundle = [NSBundle bundleForClass:[self class]];
     NSString *filename;
     if (schemeType == KKColorsSchemeTypeCrayola) {
         filename = @"colors_crayola";
@@ -32,7 +33,7 @@
         filename = @"colors_pantone";
     }
     
-    NSString *path = [[NSBundle mainBundle] pathForResource:filename ofType:@"plist"];
+    NSString *path = [podbundle pathForResource:filename ofType:@"plist"];
     NSDictionary *root = [[NSDictionary alloc] initWithContentsOfFile:path];
     NSArray *colorsArray = root[@"colors"];
     NSMutableArray *colors = [NSMutableArray array];
@@ -40,7 +41,7 @@
     for (NSDictionary *colorDict in colorsArray) {
         NSString *colorName = colorDict[@"name"];
         NSString *colorHash = colorDict[@"hash"];
-        KKColor *color = [[KKColor alloc] initWithName:colorName colorHash:colorHash];
+        KKColor *color = [[KKColor alloc] initWithName:colorName hash:colorHash];
         [colors addObject:color];
     }
     

--- a/src/KKColorListPicker/Controllers/KKColorListViewController.m
+++ b/src/KKColorListPicker/Controllers/KKColorListViewController.m
@@ -59,9 +59,10 @@
 - (void)initUI
 {
     [self createCollectionView];
+    NSBundle *podbundle = [NSBundle bundleForClass:[self class]];
     
-    [self.colorsCollection registerNib:[UINib nibWithNibName:@"KKColorCell" bundle:nil] forCellWithReuseIdentifier:@"KKColorCell"];
-    [self.colorsCollection registerNib:[UINib nibWithNibName:@"KKColorsHeaderView" bundle:nil] forSupplementaryViewOfKind:UICollectionElementKindSectionHeader withReuseIdentifier:@"KKColorsHeaderView"];
+    [self.colorsCollection registerNib:[UINib nibWithNibName:@"KKColorCell" bundle:podbundle] forCellWithReuseIdentifier:@"KKColorCell"];
+    [self.colorsCollection registerNib:[UINib nibWithNibName:@"KKColorsHeaderView" bundle:podbundle] forSupplementaryViewOfKind:UICollectionElementKindSectionHeader withReuseIdentifier:@"KKColorsHeaderView"];
     self.view.backgroundColor = self.backgroundColor;
     
     if (self.navigationController) {


### PR DESCRIPTION
Hi, current version does not support latest swift installation (use_frameworks! command), as far as your code does not count that cocoapods is now storing resources separately and you have to use resources for current framework bundle.

Plus you used keyword "hash" which is kind of in conflict with whole installation so I have slightly renamed that property;)
